### PR TITLE
Feature: GB#31 – Create MovieDetails component and route setup

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -23,4 +23,9 @@ describe('<App />', () => {
     expect(screen.getByText(/Top Rated/i)).toBeInTheDocument();
     expect(screen.getByText(/Upcoming/i)).toBeInTheDocument();
   });
+  it('renders MovieDetails at "/movie/:id" route', () => {
+    renderWithRouter('/movie/123');
+    expect(screen.getByText(/movie details/i)).toBeInTheDocument();
+    expect(screen.getByText(/movie id: 123/i)).toBeInTheDocument();
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import Home from './Components/Home/Home';
 import Header from './Components/Header/Header';
 import { WishlistProvider } from './Context/WishlistContext';
+import MovieDetails from './Components/MovieDetails/MovieDetails';
 
 export default function App() {
   return (
@@ -9,6 +10,7 @@ export default function App() {
       <Header />
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/movie/:id" element={<MovieDetails />} />
       </Routes>
     </WishlistProvider>
   );

--- a/src/Components/Header/Header.scss
+++ b/src/Components/Header/Header.scss
@@ -19,6 +19,7 @@
   .header__logo {
     font-size: 1.5rem;
     font-weight: bold;
+    cursor: pointer;
   }
 
   .header__wishlist {

--- a/src/Components/Header/Header.test.tsx
+++ b/src/Components/Header/Header.test.tsx
@@ -2,11 +2,14 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import Header from './Header';
 import { WishlistProvider } from '../../Context/WishlistContext';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryRouter } from 'react-router';
 const renderWithContext = () =>
   render(
-    <WishlistProvider>
-      <Header />
-    </WishlistProvider>
+    <MemoryRouter>
+      <WishlistProvider>
+        <Header />
+      </WishlistProvider>
+    </MemoryRouter>
   );
 
 describe('Header component', () => {

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -1,14 +1,15 @@
 import { useState, useRef } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStar } from '@fortawesome/free-solid-svg-icons';
+import { useNavigate } from 'react-router-dom';
 
 import './Header.scss';
 import { useClickOutside } from './Hooks/useClickOutside';
 import { useWishlist } from '../../Context/WishlistContext';
-
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
   const { wishlist } = useWishlist();
+  const navigate = useNavigate();
 
   const popoverRef = useRef<HTMLDivElement>(null);
   useClickOutside(popoverRef, () => setIsOpen(false), isOpen);
@@ -16,7 +17,9 @@ export default function Header() {
   return (
     <header className="header">
       <div className="header__container">
-        <h1 className="header__logo">Movie Browser</h1>
+        <h1 className="header__logo" onClick={() => navigate('/')}>
+          Movie Browser
+        </h1>
         <div className="header__wishlist" ref={popoverRef}>
           <button className="wishlist__button" onClick={() => setIsOpen((prev) => !prev)}>
             <FontAwesomeIcon icon={faStar} className="wishlist__icon" />

--- a/src/Components/Home/Components/Carousel/Carousel.test.tsx
+++ b/src/Components/Home/Components/Carousel/Carousel.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import Carousel from './Carousel';
 import { vi } from 'vitest';
 import type { Movie } from '../../Types/movie.types';
+import { MemoryRouter } from 'react-router';
 
 const mockMovies: Movie[] = [
   { id: 1, title: 'Movie One', poster_path: '', backdrop_path: '' },
@@ -17,13 +18,21 @@ beforeAll(() => {
 
 describe('<Carousel />', () => {
   it('renders the carousel title', () => {
-    render(<Carousel title="Top Rated" fetchFn={vi.fn()} />);
+    render(
+      <MemoryRouter>
+        <Carousel title="Top Rated" fetchFn={vi.fn()} />
+      </MemoryRouter>
+    );
     expect(screen.getByText(/Top Rated/i)).toBeInTheDocument();
   });
 
   it('renders movies after loading', async () => {
     const fetchFn = vi.fn().mockResolvedValue({ results: mockMovies });
-    render(<Carousel title="Trending" fetchFn={fetchFn} />);
+    render(
+      <MemoryRouter>
+        <Carousel title="Trending" fetchFn={fetchFn} />
+      </MemoryRouter>
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Movie One')).toBeInTheDocument();
@@ -33,7 +42,11 @@ describe('<Carousel />', () => {
 
   it('handles dot clicks', async () => {
     const fetchFn = vi.fn().mockResolvedValue({ results: mockMovies });
-    render(<Carousel title="Dots" fetchFn={fetchFn} />);
+    render(
+      <MemoryRouter>
+        <Carousel title="Dots" fetchFn={fetchFn} />
+      </MemoryRouter>
+    );
 
     const dots = await screen.findAllByRole('button', { name: /Go to movie/i });
 
@@ -46,7 +59,11 @@ describe('<Carousel />', () => {
 
   it('calls scroll on arrow click', async () => {
     const fetchFn = vi.fn().mockResolvedValue({ results: mockMovies });
-    render(<Carousel title="Arrows" fetchFn={fetchFn} />);
+    render(
+      <MemoryRouter>
+        <Carousel title="Arrows" fetchFn={fetchFn} />
+      </MemoryRouter>
+    );
 
     const rightArrow = screen.getByLabelText('Scroll Right');
 

--- a/src/Components/Home/Components/Carousel/Components/MovieCard/MovieCard.scss
+++ b/src/Components/Home/Components/Carousel/Components/MovieCard/MovieCard.scss
@@ -5,13 +5,27 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
+  cursor: pointer;
+  border-radius: 12px;
+  overflow: hidden;
+  transition:
+    transform 0.25s ease,
+    box-shadow 0.25s ease;
+  padding-bottom: 0.25rem;
+
+  &:hover {
+    transform: scale(1.02);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+  }
+
   .image {
     width: 100%;
     height: 150px;
-    border-radius: 8px;
     object-fit: cover;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    border-radius: 12px 12px 0 0;
+    transition: opacity 0.3s ease;
   }
+
   .MovieCardTitle {
     margin-top: 0.4rem;
     font-size: 0.85rem;
@@ -21,5 +35,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    padding: 0 0.5rem 0.5rem;
   }
 }

--- a/src/Components/Home/Components/Carousel/Components/MovieCard/MovieCard.test.tsx
+++ b/src/Components/Home/Components/Carousel/Components/MovieCard/MovieCard.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import MovieCard from './MovieCard';
 import type { Movie } from '../../../../Types/movie.types';
+import { MemoryRouter } from 'react-router';
 
 const mockMovie: Movie = {
   id: 1,
@@ -11,7 +12,11 @@ const mockMovie: Movie = {
 
 describe('<MovieCard />', () => {
   it('renders movie image with correct src and alt', () => {
-    render(<MovieCard movie={mockMovie} />);
+    render(
+      <MemoryRouter>
+        <MovieCard movie={mockMovie} />
+      </MemoryRouter>
+    );
 
     const img = screen.getByRole('img', { name: /inception/i });
     expect(img).toBeInTheDocument();
@@ -20,7 +25,11 @@ describe('<MovieCard />', () => {
   });
 
   it('displays the movie title', () => {
-    render(<MovieCard movie={mockMovie} />);
+    render(
+      <MemoryRouter>
+        <MovieCard movie={mockMovie} />
+      </MemoryRouter>
+    );
     expect(screen.getByText(mockMovie.title)).toBeInTheDocument();
   });
 });

--- a/src/Components/Home/Components/Carousel/Components/MovieCard/MovieCard.tsx
+++ b/src/Components/Home/Components/Carousel/Components/MovieCard/MovieCard.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { TMDB_IMAGE_BASE_URL } from '../../../../../../Api/Constants/apiConstants';
 import type { Movie } from '../../../../Types/movie.types';
 import './MovieCard.scss';
@@ -7,11 +8,17 @@ type Props = {
 };
 
 export default function MovieCard({ movie }: Props) {
+  const navigate = useNavigate();
+
   const getImageUrl = (path: string, size: string = 'w780') =>
     `${TMDB_IMAGE_BASE_URL}${size}${path}`;
 
+  const handleClick = () => {
+    navigate(`/movie/${movie.id}`);
+  };
+
   return (
-    <div className="card">
+    <div className="card" onClick={handleClick} role="button" tabIndex={0}>
       <img
         src={getImageUrl(movie.backdrop_path)}
         alt={movie.title}

--- a/src/Components/MovieDetails/MovieDetails.tsx
+++ b/src/Components/MovieDetails/MovieDetails.tsx
@@ -1,0 +1,12 @@
+import { useParams } from 'react-router-dom';
+
+export default function MovieDetails() {
+  const { id } = useParams();
+
+  return (
+    <main className="movie-details">
+      <h1>Movie Details</h1>
+      <p>Movie ID: {id}</p>
+    </main>
+  );
+}


### PR DESCRIPTION
# GB#31 – Create MovieDetails component and route setup

### 📌 Summary

This PR completes GB#31 by introducing the base `MovieDetails` page and setting up routing from `App.tsx` and `MovieCard`. The route `/movie/:id` now loads a dedicated component that reads the movie ID from the URL and renders a placeholder view.

---

### ✨ Tasks Completed

- GB#311 – Create `MovieDetails.tsx` inside `Components/MovieDetails/`
- GB#312 – Add new route `/movie/:id` to `App.tsx`
- GB#313 – Enable navigation from `MovieCard` using `useNavigate`
- GB#314 – Add unit tests for routing and initial render

---

### 🧪 Tests

- `App.test.tsx` validates rendering of `MovieDetails` on route `/movie/:id`
- Basic test for ID param extraction and display
